### PR TITLE
Object processing in the parameterProcessing

### DIFF
--- a/base/parameterProcessor.class.js
+++ b/base/parameterProcessor.class.js
@@ -23,26 +23,39 @@ class ParameterProcessor {
   }
 
   validateParameters(param, requestData) {
+    
     let responseObj = { error: null, value: null };
-    // Check Type of parameter
-    let paramData = this.convertToGivenParameterType(param, requestData);
 
-    //Check if param is declared as Mandatory or Optional in InitClass
-    let validatedData = this.verifyRequiredParameter(param, paramData);
-    if (validatedData.error) {
-      responseObj.error = { errorCode: "INVALID_INPUT_EMPTY", parameterName: param.name };
+    try {
+    
+      // Check Type of parameter
+      let paramData = this.convertToGivenParameterType(param, requestData);
+
+      //Check if param is declared as Mandatory or Optional in InitClass
+      let validatedData = this.verifyRequiredParameter(param, paramData);
+      if (validatedData.error) {
+        responseObj.error = { errorCode: "INVALID_INPUT_EMPTY", parameterName: param.name };
+        return responseObj;
+      }
+
+      //Set Default value to param when it is Optional
+      responseObj.value = this.setDefaultParameters(param, validatedData.data);
       return responseObj;
-    }
+    } catch (e) {
 
-    //Set Default value to param when it is Optional
-    responseObj.value = this.setDefaultParameters(param, validatedData.data);
-    return responseObj;
+      console.log("ValidateParameters: ",e);    
+      if( e.errorCode )
+        responseObj.error = { errorCode: e.code, parameterName: e.name }
+      else
+        responseObj.error = {errorCode: "UNKNOWN_ERROR"};
+      return responseObj
+    }
   }
 
   //converts all the request parameters to the specified type(number and string)
   convertToGivenParameterType(paramData, requestData) {
     let res;
-    switch (paramData.type) {
+    switch (paramData.type.toLowerCase()) {
       case "number":
         res = Number(requestData);
         // set error response if a parameter is specified in request but is not an integer
@@ -54,6 +67,21 @@ class ParameterProcessor {
       case "string":
         if (!requestData) return;
         res = requestData.toString();
+        break;
+      
+      case "object": 
+        if (!requestData) return;
+
+        if ( typeof requestData === "object" ){
+          res = requestData;
+          break;
+        }
+
+        try {
+          res = JSON.parse(requestData);
+        } catch (error) {
+          throw { errorCode: "INVALID_INPUT_JSON", name: requestData.name };
+        }
         break;
 
       case "file":

--- a/i18n/response.js
+++ b/i18n/response.js
@@ -64,6 +64,12 @@ const RESPONSE = {
       "en": "Something went wrong",
       "es": "Algo salió mal"
     }
+  },
+  INVALID_INPUT_JSON:{ 
+    responseCode: 100012, responseMessage: {
+      "en": "paramName should be a valid JSON",
+      "es": "paramName debe ser un JSON válido"
+    }
   }
 };
 


### PR DESCRIPTION
Why this feature?
> Previously we need to manually verify and parse object and return the error if its not valid JSON object.
> To avoid, This feature is integrated

Files changed,
>  i18n/response.js - added INVALID_INPUT_RESPONSE object to throw error
>  parameterProcessor.class.js - parsed JSON object and throw error response