### PR TITLE
Remove try catch from mongo.lib.js

### DIFF
--- a/template/libraryStructure/mongo/mongo.lib.js
+++ b/template/libraryStructure/mongo/mongo.lib.js
@@ -3,51 +3,31 @@ const { init<function-name>Model } = require("./model/<class-name>");
 class <class-name> {
 
   async get<function-name>Detail(query, options = []) {
-    try {
-      let <class-name>Model = await init<function-name>Model();
-      return await <class-name>Model.findOne(query).lean();
-    } catch (e) {
-      console.log(e);
-    }
+    let <class-name>Model = await init<function-name>Model();
+    return await <class-name>Model.findOne(query).lean();
   }
 
   async get<function-name>List(query, options = []) {
-    try {
-      let <class-name>Model = await init<function-name>Model();
-      return await <class-name>Model.find(query).lean();
-    } catch (e) {
-      console.log(e);
-    }
+    let <class-name>Model = await init<function-name>Model();
+    return await <class-name>Model.find(query).lean();
   }
   
   async update<function-name>(query, data) {
-    try {
-      let <class-name>Model = await init<function-name>Model();
-      return await <class-name>Model.findOneAndUpdate(query, data, {
-        new: true
-      });
-    } catch (e) {
-      console.log(e);
-    }
+    let <class-name>Model = await init<function-name>Model();
+    return await <class-name>Model.findOneAndUpdate(query, data, {
+      new: true
+    });
   }
 
   async create<function-name>(data) {
-    try {
-      let <class-name>Model = await init<function-name>Model();
-      let new<function-name> = new <class-name>Model(data);
-      return new<function-name>.save();
-    } catch (e) {
-      console.log(e);
-    }
+    let <class-name>Model = await init<function-name>Model();
+    let new<function-name> = new <class-name>Model(data);
+    return new<function-name>.save();
   }
   
   async delete<function-name>(query) {
-    try {
-      let <class-name>Model = await init<function-name>Model();
-      return await <class-name>Model.findOneAndDelete(query);
-    } catch (e) {
-      console.log(e);
-    }
+    let <class-name>Model = await init<function-name>Model();
+    return await <class-name>Model.findOneAndDelete(query);
   }
 }
 


### PR DESCRIPTION
Removing try catch from mongo.lib.js helps developers handle the exception through code. This also fixes issue where API might respond SUCCESS even if the mongodb operation failed