### PR TITLE
fixed: socket io does not emit when rest API

### DIFF
--- a/template/frameworkStructure/express.js
+++ b/template/frameworkStructure/express.js
@@ -8,12 +8,14 @@ AutoLoad.loadConfig();
 AutoLoad.loadModules();
 
 const { Executor, sockets } = require("@njs2/base");
-sockets.init();
 
 /* External Package imports */
 const app = express();
 const upload = multer();
 const server = http.createServer(app);
+
+// Version 2.5.0 with Socket.io Server starting from the same port
+sockets.init(server);
 
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));

--- a/template/frameworkStructure/express.js
+++ b/template/frameworkStructure/express.js
@@ -7,7 +7,8 @@ AutoLoad = require('@njs2/base/base/autoload.class');
 AutoLoad.loadConfig();
 AutoLoad.loadModules();
 
-const { Executor } = require("@njs2/base");
+const { Executor, sockets } = require("@njs2/base");
+sockets.init();
 
 /* External Package imports */
 const app = express();

--- a/template/frameworkStructure/socketio.js
+++ b/template/frameworkStructure/socketio.js
@@ -3,7 +3,7 @@ AutoLoad.loadConfig();
 AutoLoad.loadModules();
 
 const { Executor, sockets } = require("@njs2/base");
-sockets.init();
+// sockets.init();
 
 const { CONNECTION_HANDLER_METHOD, DISCONNECTION_HANDLER_METHOD } = require('./src/global/constants');
 


### PR DESCRIPTION
**Bug**: When we call any API if we use `SOCKETManager.emit` with proper connection_id it does not send/emit any message.

**Fix** - As `socketio.js` and `express.js` ran separately the connections are not shared between express.js and socketio.js so moved init function to express.js so now from both rest API also emit works.