### PR TITLE
BugFix: for 2.4.0-0

### DIFF
--- a/base/executor.class.js
+++ b/base/executor.class.js
@@ -266,10 +266,10 @@ class executor {
       const resultTemplate = compiled(RESP);
 
       const matcherObj = {
-          '"{{': '{',
-          '}}"': '}',
-          '"{[': '[',
-          ']}"': ']'
+          '{{': '{',
+          '}}': '}',
+          '{[': '[',
+          ']}': ']'
       }
 
       const replacedString = multiReplace(resultTemplate, matcherObj); 


### PR DESCRIPTION
In executor.class.js string multi-replace matcher object has additional quotes