### PR TITLE
Added polling fallback in socket.io for connection stability

### DIFF
--- a/sockets/socketio.js
+++ b/sockets/socketio.js
@@ -1,7 +1,7 @@
 const path = require("path");
 const io = require("socket.io")({
   serveClient: false,
-  transports: ["websocket"],
+  transports: ["websocket", "polling"],
   cors: {
     origin: "*",
   },


### PR DESCRIPTION
Socket.io connection fails while trying to do a websocket connection in some cases. Adding `polling` as fallback option will successfully establish a socket.io connection.